### PR TITLE
Chore/test ci

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,5 +21,3 @@ jobs:
       - name: Lint code
         run: ./redscript-cli.exe lint --src ${{ env.REDSCRIPT_SRC }}
         continue-on-error: true
-      - name: Compile code
-        run: ./redscript-cli.exe compile --src ${{ env.REDSCRIPT_SRC }} --bundle dump.redscript --output dump.reds


### PR DESCRIPTION
Add a linter for REDscript.
Compilation can be tested but requires the addition of a _.redscripts_ (found in game folder under `r6/cache/final.redscripts`) whose size is over 10Mb in mine (probably varies depending on previously installed mods).
Ideally basic _.redscripts_ files for different combo of mods could be used, but as of now compilation is skipped.