### PR TITLE
Chore/codeblocks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install mdbook
         run: |
           mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.22/mdbook-v0.4.22-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo `pwd`/mdbook >> $GITHUB_PATH
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
see [related Action log](https://github.com/cyb3rpsych0s1s/4ddicted/actions/runs/4782317883/jobs/8501539400):

```sh
[2023-04-24T04:03:34Z ERROR mdbook_codeblocks::preprocessor] The codeblocks plugin was built against version 0.4.28 of mdbook, but we're being called from version 0.4.22, so may be incompatible.
```