### PR TITLE
Strip reds files of comments and logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   WOLVENKIT_CLI_VERSION: '8.13.0'
   DOTNET_VERSION: '8.0.x'
   IS_DRAFT: ${{ startsWith(github.ref_name, 'beta') || startsWith(github.ref_name, 'alpha') }}
+  IS_RELEASE: ${{ ! startsWith(github.ref_name, 'rc') }}
 
 jobs:
   bundle-mod:
@@ -24,6 +25,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup Cargo binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: Setup srgn
+        run: cargo binstall --no-confirm srgn
       - name: Setup Just
         uses: extractions/setup-just@v2
         env:
@@ -39,6 +44,9 @@ jobs:
           dotnet tool install -g wolvenkit.cli
         env:
           WOLVENKIT_ARTIFACT: WolvenKit.Console-${{ env.WOLVENKIT_CLI_VERSION }}.zip
+      - name: Strip files
+        if: ${{ env.IS_RELEASE }}
+        run: just sweep
       - name: Bundle files
         run: just ci 'mod-windows'
         env:

--- a/justfile
+++ b/justfile
@@ -65,3 +65,7 @@ default:
 
 @encode LOCALE='en-us' OVERWRITE='false':
   just recipes/audioware/encode '{{LOCALE}}' '{{OVERWRITE}}'
+
+# 🧹 strip comments and logs (for release in CI)
+@sweep:
+  just recipes/red/sweep

--- a/recipes/red/justfile
+++ b/recipes/red/justfile
@@ -12,3 +12,8 @@ tree     := join('r6', 'scripts')
 
 @uninstall FROM:
     just trash '{{ join(FROM, tree, mod) }}'
+
+@sweep:
+    cd '{{source}}'; srgn --files 'Addicted/**/*.reds' --delete '\n?[[:space:]]*///* .+'
+    cd '{{source}}'; srgn --files 'Addicted/**/*.reds' --delete '\n?[[:space:]]*(E|EI|F|FI)\(.+(?<=\);)'
+    cd '{{source}}'; srgn --files 'Addicted/**/*.reds' --delete '\n?[[:space:]]*import Addicted\.Utils\..+'


### PR DESCRIPTION
This PR implies releases in two phases, if merged:
- `rcX.Y.Z` releases with reds files untouched, to allow contributors to keep on being able to test with debug capabilities
- followed by `alphaX.Y.Z`, `betaX.Y.Z` or `vX.Y.Z` releases with reds files stripped of comments and debug

It implies removing any multiline comments across the entire reds codebase (making single-line comments mandatory) or improving `sweep` to support them before merging.

It provides best of both worlds while adding on technical debt, so it should be considered before final decision.