### PR TITLE
Fix ItemID comparison

### DIFF
--- a/scripts/Addicted/Definitions.reds
+++ b/scripts/Addicted/Definitions.reds
@@ -154,8 +154,10 @@ public class Consumptions {
   }
   public func Items() -> array<ItemID> {
     let items: array<ItemID> = [];
+    let appellation: ItemID;
     for key in this.keys {
-      ArrayPush(items, ItemID.FromTDBID(key));
+      appellation = ItemID.CreateQuery(key);
+      ArrayPush(items, appellation);
     }
     return items;
   }

--- a/scripts/Addicted/Definitions.reds
+++ b/scripts/Addicted/Definitions.reds
@@ -126,11 +126,6 @@ public class Consumptions {
     if idx == -1 { return null; }
     return this.values[idx];
   }
-  public func Set(id: ItemID, value: ref<Consumption>) -> Void {
-    let idx = this.Index(id);
-    if idx == -1 { return; }
-    this.values[idx] = value;
-  }
   public func KeyExist(id: ItemID) -> Bool {
     let idx = this.Index(id);
     return idx != -1;

--- a/scripts/Addicted/System.reds
+++ b/scripts/Addicted/System.reds
@@ -529,7 +529,8 @@ public class AddictedSystem extends ScriptableSystem {
       // otherwise always cross the threshold
       amount = amount + 1;
     }
-    this.Consume(ItemID.FromTDBID(id), amount);
+    let item = ItemID.CreateQuery(id);
+    this.Consume(item, amount);
   }
 
   public func Checkup() -> Void {

--- a/scripts/Addicted/Tweaks.reds
+++ b/scripts/Addicted/Tweaks.reds
@@ -84,9 +84,13 @@ protected cb func OnAction(action: ListenerAction, consumer: ListenerActionConsu
 @addMethod(PlayerPuppet)
 public func HasBiomonitor() -> Bool {
   let system = EquipmentSystem.GetInstance(this);
-  let biomonitors = Helper.Biomonitors();
+  let biomonitors: array<TweakDBID> = Helper.Biomonitors();
+  let item: ItemID;
+  let equipped: Bool;
   for biomonitor in biomonitors {
-    if system.IsEquipped(this, ItemID.FromTDBID(biomonitor)) {
+    item = ItemID.CreateQuery(biomonitor);
+    equipped = system.IsEquipped(this, item);
+    if equipped {
       return true;
     }
   }
@@ -96,13 +100,17 @@ public func HasBiomonitor() -> Bool {
 @addMethod(PlayerPuppet)
 public func HasDetoxifier() -> Bool {
   let system = EquipmentSystem.GetInstance(this);
-  return system.IsEquipped(this, ItemID.FromTDBID(t"Items.ToxinCleanser"));
+  let detox = ItemID.CreateQuery(t"Items.ToxinCleanser");
+  let equipped = system.IsEquipped(this, detox);
+  return equipped;
 }
 
 @addMethod(PlayerPuppet)
 public func HasMetabolicEditor() -> Bool {
   let system = EquipmentSystem.GetInstance(this);
-  return system.IsEquipped(this, ItemID.FromTDBID(t"Items.ReverseMetabolicEnhancer"));
+  let editor = ItemID.CreateQuery(t"Items.ReverseMetabolicEnhancer");
+  let equipped = system.IsEquipped(this, editor);
+  return equipped;
 }
 
 @addMethod(PlayerPuppet)


### PR DESCRIPTION
As it turns out, comparing `ItemID` derived from `TweakDBID` must be done using an `ItemID` generated from `ItemID.CreateQuery` instead of `ItemID.FromTDBID`.

See discussion on [Discord](https://discord.com/channels/717692382849663036/804399334246187038/1226369013425377392):
![Screenshot 2024-04-07 113246](https://github.com/cyb3rpsych0s1s/4ddicted/assets/21016014/4d41fdda-23b3-42bd-a20d-2934d541d3f8)
