### PR TITLE
Temporary fix for REDmod warning

### DIFF
--- a/audioware/info.json
+++ b/audioware/info.json
@@ -1,0 +1,5 @@
+{
+    "name": "Addicted",
+    "version": "1.0.0",
+    "customSounds": []
+}

--- a/recipes/audioware/justfile
+++ b/recipes/audioware/justfile
@@ -13,6 +13,7 @@ tree     := 'mods'
     just dcopy '{{ join(source, LOCALE) }}' '{{ join(TO, tree, mod) }}'
     just dcopy '{{ join(source, "vanilla", LOCALE) }}' '{{ join(TO, tree, mod, "vanilla") }}'
     just copy '{{ join(source, "voices." + LOCALE + ".yml") }}' '{{ join(TO, tree, mod, "voices.yml") }}'
+    just copy '{{ join(source, "info.json") }}' '{{ join(TO, tree, mod, "info.json") }}'
 
 @uninstall FROM:
     just trash '{{ join(FROM, tree, mod) }}'


### PR DESCRIPTION
As suggested by [abi](https://www.nexusmods.com/users/96950) on Nexus, temporarily add fake `info.json` for REDmod.