### PR TITLE
Use highest threshold for Healers

### DIFF
--- a/scripts/Addicted/System.reds
+++ b/scripts/Addicted/System.reds
@@ -595,6 +595,7 @@ public class AddictedSystem extends ScriptableSystem {
   }
 
   public func Threshold(addiction: Addiction) -> Threshold {
+    if Equals(addiction, Addiction.Healers) { return this.consumptions.HighestThreshold(addiction); }
     return this.consumptions.Threshold(addiction);
   }
 


### PR DESCRIPTION
Simple change so that the `Threshold` for any `Healer` is always the highest one of all.